### PR TITLE
Add basic telemetry client and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# RbxTelemetry
+
+A lightweight Python client for batching and sending telemetry events to a
+remote HTTP endpoint.  Events are collected locally and can be flushed to the
+server in batches.
+
+## Usage
+
+```python
+from rbxtelemetry import TelemetryClient
+
+client = TelemetryClient("https://example.com/telemetry")
+client.log_event("game_start", {"user": "Alice"})
+client.flush()
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rbxtelemetry"
+version = "0.1.0"
+description = "Simple telemetry client for batching events"
+authors = [{ name = "Ecliptorhize" }]
+readme = "README.md"
+requires-python = ">=3.8"

--- a/rbxtelemetry/__init__.py
+++ b/rbxtelemetry/__init__.py
@@ -1,0 +1,7 @@
+"""rbxtelemetry package."""
+
+from .telemetry import TelemetryClient
+
+__all__ = ["TelemetryClient"]
+
+__version__ = "0.1.0"

--- a/rbxtelemetry/telemetry.py
+++ b/rbxtelemetry/telemetry.py
@@ -1,0 +1,92 @@
+"""Telemetry client for sending events to a server.
+
+This module exposes :class:`TelemetryClient` which collects events and sends
+them to a remote HTTP endpoint.  It keeps a local queue so events can be
+batched via :meth:`flush`.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Callable, Dict, List, Optional, Any
+
+
+Sender = Callable[[str, Dict[str, Any]], None]
+
+
+class TelemetryClient:
+    """Collects and sends telemetry events.
+
+    Parameters
+    ----------
+    server_url:
+        Endpoint where events will be POSTed as JSON.
+    session_id:
+        Optional identifier for the current session.  One will be generated
+        automatically if not provided.
+    sender:
+        Optional callable used to transmit events.  Defaults to a small wrapper
+        around :func:`requests.post`.  This is mainly to ease testing since a
+        custom sender can be injected.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        *,
+        session_id: Optional[str] = None,
+        sender: Optional[Sender] = None,
+    ) -> None:
+        self.server_url = server_url
+        self.session_id = session_id or str(uuid.uuid4())
+        self._sender: Sender = sender or self._default_sender
+        self._queue: List[Dict[str, Any]] = []
+
+    def log_event(self, name: str, data: Optional[Dict[str, Any]] = None) -> None:
+        """Add an event to the queue.
+
+        Parameters
+        ----------
+        name:
+            Name of the event.
+        data:
+            Optional mapping with extra information for the event.
+        """
+        event = {
+            "name": name,
+            "timestamp": time.time(),
+            "data": data or {},
+        }
+        self._queue.append(event)
+
+    def flush(self) -> int:
+        """Send queued events to the server.
+
+        Returns
+        -------
+        int
+            The number of events that were transmitted.
+        """
+        if not self._queue:
+            return 0
+
+        payload = {"session_id": self.session_id, "events": self._queue}
+        self._sender(self.server_url, payload)
+        sent = len(self._queue)
+        self._queue = []
+        return sent
+
+    @staticmethod
+    def _default_sender(url: str, payload: Dict[str, Any]) -> None:
+        """Send the payload using :mod:`requests`.
+
+        Network errors are intentionally swallowed since telemetry should not
+        disrupt the main application flow.
+        """
+        try:
+            import requests
+
+            requests.post(url, json=payload, timeout=5)
+        except Exception:
+            pass

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,23 @@
+from rbxtelemetry import TelemetryClient
+
+
+def test_log_and_flush():
+    sent_payloads = []
+
+    def sender(url, payload):
+        sent_payloads.append((url, payload))
+
+    client = TelemetryClient("https://example.com/telemetry", sender=sender)
+    client.log_event("start", {"user": "Bob"})
+
+    assert len(client._queue) == 1
+    sent = client.flush()
+    assert sent == 1
+    assert len(client._queue) == 0
+
+    assert sent_payloads[0][0] == "https://example.com/telemetry"
+    payload = sent_payloads[0][1]
+    assert payload["session_id"]
+    events = payload["events"]
+    assert events[0]["name"] == "start"
+    assert events[0]["data"] == {"user": "Bob"}


### PR DESCRIPTION
## Summary
- Implement TelemetryClient for batching and sending events to an HTTP endpoint
- Provide project metadata and documentation
- Add unit tests for event logging and flushing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6be725ca88322ac5389d88e566cf2